### PR TITLE
URL Cleanup

### DIFF
--- a/docs/src/reference/docbook/api.xml
+++ b/docs/src/reference/docbook/api.xml
@@ -16,7 +16,7 @@ Gowalla gowalla = new GowallaTemplate(accessToken);]]>
 	</programlisting>
 		
 	<para>
-		If you are using Spring Social's <ulink url="http://static.springsource.org/spring-social/docs/1.0.x/reference/html/serviceprovider.html">service provider framework</ulink>, you can get an instance of <interfacename>Gowalla</interfacename> via a <interfacename>Connection</interfacename>. 
+		If you are using Spring Social's <ulink url="https://docs.spring.io/spring-social/docs/1.0.x/reference/html/serviceprovider.html">service provider framework</ulink>, you can get an instance of <interfacename>Gowalla</interfacename> via a <interfacename>Connection</interfacename>. 
 		For example, the following snippet calls <methodname>getApi()</methodname> on a connection to retrieve a <interfacename>Gowalla</interfacename>:
 	</para>				
 	

--- a/docs/src/reference/docbook/connecting.xml
+++ b/docs/src/reference/docbook/connecting.xml
@@ -63,7 +63,7 @@ public class SocialConfig {
 	</para>	
 		
 	<para>
-		Refer to <ulink url="http://static.springsource.org/spring-social/docs/1.0.x/reference/html/connecting.html">Spring Social's reference documentation</ulink> for complete details on configuring <classname>ConnectController</classname> and its dependencies.
+		Refer to <ulink url="https://docs.spring.io/spring-social/docs/1.0.x/reference/html/connecting.html">Spring Social's reference documentation</ulink> for complete details on configuring <classname>ConnectController</classname> and its dependencies.
 	</para>
 		
 </chapter>

--- a/docs/src/reference/docbook/overview.xml
+++ b/docs/src/reference/docbook/overview.xml
@@ -7,11 +7,11 @@
 		<title>Introduction</title>
 
 		<para>
-			The Spring Social Gowalla project is an extension to <ulink url="http://www.springframework.org/spring-social">Spring Social</ulink> that enables integration with Gowalla.
+			The Spring Social Gowalla project is an extension to <ulink url="https://www.springframework.org/spring-social">Spring Social</ulink> that enables integration with Gowalla.
 		</para>
 		
 		<para>
-			<ulink url="http://www.gowalla.com">Gowalla</ulink> is a location-based social network where users may check in to various locations they visit and earn pins and stamps for having checked in a locations that achieve some goal (for example, a "Lucha Libre" pin may be earned by having checked into 10 different Mexican food restaurants).
+			<ulink url="https://www.gowalla.com">Gowalla</ulink> is a location-based social network where users may check in to various locations they visit and earn pins and stamps for having checked in a locations that achieve some goal (for example, a "Lucha Libre" pin may be earned by having checked into 10 different Mexican food restaurants).
 		</para>
 		
 		<para>
@@ -54,7 +54,7 @@
 		</para>
 
 		<para>
-			Consult <ulink url="http://static.springsource.org/spring-social/docs/1.0.x/reference/html/overview.html#overview-howtoget">Spring Social's reference documentation</ulink> for more information on Spring Social dependencies.
+			Consult <ulink url="https://docs.spring.io/spring-social/docs/1.0.x/reference/html/overview.html#overview-howtoget">Spring Social's reference documentation</ulink> for more information on Spring Social dependencies.
 		</para>
 	</section>
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://www.gowalla.com (UnknownHostException) with 1 occurrences migrated to:  
  https://www.gowalla.com ([https](https://www.gowalla.com) result UnknownHostException).
* http://www.springframework.org/spring-social (404) with 1 occurrences migrated to:  
  https://www.springframework.org/spring-social ([https](https://www.springframework.org/spring-social) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://static.springsource.org/spring-social/docs/1.0.x/reference/html/connecting.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-social/docs/1.0.x/reference/html/connecting.html ([https](https://static.springsource.org/spring-social/docs/1.0.x/reference/html/connecting.html) result 200).
* http://static.springsource.org/spring-social/docs/1.0.x/reference/html/overview.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-social/docs/1.0.x/reference/html/overview.html ([https](https://static.springsource.org/spring-social/docs/1.0.x/reference/html/overview.html) result 200).
* http://static.springsource.org/spring-social/docs/1.0.x/reference/html/serviceprovider.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-social/docs/1.0.x/reference/html/serviceprovider.html ([https](https://static.springsource.org/spring-social/docs/1.0.x/reference/html/serviceprovider.html) result 200).

# Ignored
These URLs were intentionally ignored.

* http://docbook.org/ns/docbook with 4 occurrences
* http://www.w3.org/1999/xlink with 4 occurrences
* http://www.w3.org/2001/XInclude with 1 occurrences