### PR TITLE
URL Cleanup

### DIFF
--- a/docs/src/api/overview.html
+++ b/docs/src/api/overview.html
@@ -5,7 +5,7 @@ This document is the API specification for Spring Social Gowalla
 <div id="overviewBody">
     <p>
         If you are interested in commercial training, consultancy, and
-        support for Spring Social Gowalla, please visit <a href="http://www.springsource.com/" target="_top">SpringSource.com</a>.
+        support for Spring Social Gowalla, please visit <a href="https://www.springsource.com/" target="_top">SpringSource.com</a>.
     </p>
 </div>
 </body>

--- a/docs/src/info/notice.txt
+++ b/docs/src/info/notice.txt
@@ -4,13 +4,13 @@
    ===========================================================================
 
    This product includes software developed by
-   the Apache Software Foundation (http://www.apache.org).
+   the Apache Software Foundation (https://www.apache.org).
 
    The end-user documentation included with a redistribution, if any,
    must include the following acknowledgement:
 
      "This product includes software developed by the Spring Framework
-      Project (http://www.springframework.org)."
+      Project (https://www.springframework.org)."
 
    Alternatively, this acknowledgement may appear in the software itself,
    if and wherever such third-party acknowledgements normally appear.

--- a/docs/src/info/readme.txt
+++ b/docs/src/info/readme.txt
@@ -5,7 +5,7 @@ Spring Social Gowalla is an extension of Spring Social for connecting with Gowal
 To find out what has changed in this release, see 'changelog.txt'
 
 Please consult the documentation located within the 'docs/reference' directory of this release and also visit the official Spring Social home at:
-http://www.springsource.org/spring-social
+https://www.springsource.org/spring-social
 
 There you will find links to the forum, issue tracker, samples, and other resources.
  

--- a/docs/src/reference/resources/xsl/html-custom.xsl
+++ b/docs/src/reference/resources/xsl/html-custom.xsl
@@ -20,7 +20,7 @@
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-				xmlns:xslthl="http://xslthl.sf.net"
+				xmlns:xslthl="http://xslthl.sourceforge.net/"
 				exclude-result-prefixes="xslthl"
 				version='1.0'>
 
@@ -118,7 +118,7 @@
 	<xsl:template name="user.head.content">
 		<xsl:comment>Begin Google Analytics code</xsl:comment>
 		<script type="text/javascript">
-			var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+			var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "https://www.");
 			document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
 		</script>
 		<script type="text/javascript">

--- a/docs/src/reference/resources/xsl/html-single-custom.xsl
+++ b/docs/src/reference/resources/xsl/html-single-custom.xsl
@@ -20,7 +20,7 @@
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:xslthl="http://xslthl.sf.net"
+                xmlns:xslthl="http://xslthl.sourceforge.net/"
                 exclude-result-prefixes="xslthl"
                 version='1.0'>
 
@@ -115,7 +115,7 @@
     <xsl:template name="user.head.content">
 <xsl:comment>Begin Google Analytics code</xsl:comment>
 <script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "https://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
 </script>
 <script type="text/javascript">

--- a/docs/src/reference/resources/xsl/pdf-custom.xsl
+++ b/docs/src/reference/resources/xsl/pdf-custom.xsl
@@ -21,7 +21,7 @@
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
-                xmlns:xslthl="http://xslthl.sf.net"
+                xmlns:xslthl="http://xslthl.sourceforge.net/"
                 exclude-result-prefixes="xslthl"
                 version='1.0'>
     <xsl:import href="http://docbook.sourceforge.net/release/xsl/current/fo/docbook.xsl"/>

--- a/spring-social-gowalla/src/main/java/org/springframework/social/gowalla/api/impl/GowallaTemplate.java
+++ b/spring-social-gowalla/src/main/java/org/springframework/social/gowalla/api/impl/GowallaTemplate.java
@@ -75,7 +75,7 @@ public class GowallaTemplate extends AbstractOAuth2ApiBinding implements Gowalla
 	}
 
 	public String getProfileUrl() {
-		return "http://www.gowalla.com/users/" + getProfileId();
+		return "https://www.gowalla.com/users/" + getProfileId();
 	}
 	
 	public List<Checkin> getTopCheckins(String userId) {

--- a/spring-social-gowalla/src/test/java/org/springframework/social/gowalla/api/impl/GowallaTemplateTest.java
+++ b/spring-social-gowalla/src/test/java/org/springframework/social/gowalla/api/impl/GowallaTemplateTest.java
@@ -61,7 +61,7 @@ public class GowallaTemplateTest {
 		mockServer.expect(requestTo("https://api.gowalla.com/users/me")).andExpect(method(GET))
 				.andExpect(header("Authorization", "Token token=\"ACCESS_TOKEN\""))
 				.andRespond(withResponse("{\"username\":\"habuma\",\"pins_count\":17,\"stamps_count\":2}", responseHeaders));
-		assertEquals("http://www.gowalla.com/users/habuma", gowalla.getProfileUrl());
+		assertEquals("https://www.gowalla.com/users/habuma", gowalla.getProfileUrl());
 	}
 
 	@Test

--- a/spring-social-gowalla/src/test/java/org/springframework/social/gowalla/connect/GowallaAdapterTest.java
+++ b/spring-social-gowalla/src/test/java/org/springframework/social/gowalla/connect/GowallaAdapterTest.java
@@ -31,7 +31,7 @@ public class GowallaAdapterTest {
 	
 	@Test
 	public void fetchProfile() {		
-		Mockito.when(gowalla.getUserProfile()).thenReturn(new GowallaProfile("habuma", "Craig", "Walls", "Plano, TX", 1, 2, "http://s3.amazonaws.com/static.gowalla.com/users/362641-standard.jpg?1294162106"));
+		Mockito.when(gowalla.getUserProfile()).thenReturn(new GowallaProfile("habuma", "Craig", "Walls", "Plano, TX", 1, 2, "https://s3.amazonaws.com/static.gowalla.com/users/362641-standard.jpg?1294162106"));
 		UserProfile profile = apiAdapter.fetchUserProfile(gowalla);
 		assertEquals("Craig Walls", profile.getName());
 		assertEquals("Craig", profile.getFirstName());


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://docbook.sourceforge.net/release/xsl/current/fo/docbook.xsl (200) with 1 occurrences could not be migrated:  
   ([https](https://docbook.sourceforge.net/release/xsl/current/fo/docbook.xsl) result AnnotatedConnectException).
* [ ] http://docbook.sourceforge.net/release/xsl/current/fo/highlight.xsl (200) with 1 occurrences could not be migrated:  
   ([https](https://docbook.sourceforge.net/release/xsl/current/fo/highlight.xsl) result AnnotatedConnectException).
* [ ] http://docbook.sourceforge.net/release/xsl/current/html/chunk.xsl (200) with 1 occurrences could not be migrated:  
   ([https](https://docbook.sourceforge.net/release/xsl/current/html/chunk.xsl) result AnnotatedConnectException).
* [ ] http://docbook.sourceforge.net/release/xsl/current/html/docbook.xsl (200) with 1 occurrences could not be migrated:  
   ([https](https://docbook.sourceforge.net/release/xsl/current/html/docbook.xsl) result AnnotatedConnectException).
* [ ] http://docbook.sourceforge.net/release/xsl/current/html/highlight.xsl (200) with 2 occurrences could not be migrated:  
   ([https](https://docbook.sourceforge.net/release/xsl/current/html/highlight.xsl) result AnnotatedConnectException).
* [ ] http://xslthl.sf.net (301) with 3 occurrences could not be migrated:  
   ([https](https://xslthl.sf.net) result AnnotatedConnectException).
* [ ] http://loopfuse.net/webrecorder/js/listen.js (404) with 2 occurrences could not be migrated:  
   ([https](https://loopfuse.net/webrecorder/js/listen.js) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://www (UnknownHostException) with 2 occurrences migrated to:  
  https://www ([https](https://www) result UnknownHostException).
* [ ] http://www.gowalla.com/users/ (UnknownHostException) with 1 occurrences migrated to:  
  https://www.gowalla.com/users/ ([https](https://www.gowalla.com/users/) result UnknownHostException).
* [ ] http://www.gowalla.com/users/habuma (UnknownHostException) with 1 occurrences migrated to:  
  https://www.gowalla.com/users/habuma ([https](https://www.gowalla.com/users/habuma) result UnknownHostException).
* [ ] http://s3.amazonaws.com/static.gowalla.com/users/362641-standard.jpg?1294162106 (403) with 1 occurrences migrated to:  
  https://s3.amazonaws.com/static.gowalla.com/users/362641-standard.jpg?1294162106 ([https](https://s3.amazonaws.com/static.gowalla.com/users/362641-standard.jpg?1294162106) result 403).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org with 1 occurrences migrated to:  
  https://www.apache.org ([https](https://www.apache.org) result 200).
* [ ] http://www.springframework.org with 1 occurrences migrated to:  
  https://www.springframework.org ([https](https://www.springframework.org) result 301).
* [ ] http://www.springsource.com/ with 1 occurrences migrated to:  
  https://www.springsource.com/ ([https](https://www.springsource.com/) result 301).
* [ ] http://www.springsource.org/spring-social with 1 occurrences migrated to:  
  https://www.springsource.org/spring-social ([https](https://www.springsource.org/spring-social) result 301).

# Ignored
These URLs were intentionally ignored.

* http://docbook.sourceforge.net/xmlns/l10n/1.0 with 3 occurrences
* http://www.w3.org/1999/XSL/Format with 2 occurrences
* http://www.w3.org/1999/XSL/Transform with 3 occurrences